### PR TITLE
feat: performance and usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,49 @@
 # OpenSCAD_airfoil
-## Parametric Airfoil and Wing generator v0.1
+
+## Parametric Airfoil and Wing Generator v0.1
+
 Homepage: https://github.com/ErroneousBosch/OpenSCAD_airfoil
 
 For a brief overview of the math and specifications used, see https://en.wikipedia.org/wiki/NACA_airfoil
 
 ## Globals:
-***$close_airfoils***: Defines whether you want the back of your air foils closed, or if you want them open (default: false) 
 
-***$airfoil_fn***: number of sides for your airfoil. (default: 100) 
+**`$close_airfoils`**  _(default: `false`)_<br>Defines whether you want the back of your airfoils closed, or if you want them open.
 
-## airfoil_poly help:
+**`$airfoil_fn`**  _(default: `25`)_<br>Number of sides for your airfoil.
+
+## `airfoil_poly` parameters:
+
 This function generates a 2D polygon of an airfoil, using the following variables.
 
-***c***: Chord length, this is the chord length of your airfoil. (default: 100) 
+**`c`**  _(default: `100`)_<br>
+The chord length of your airfoil.
 
-***naca***: The NACA 4-digit specification for your airfoil. (default: 0015) 
+**`naca`**  _(default: `0015`)_<br>
+The NACA 4-digit specification for your airfoil.
 
-***raw***: overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw [.4,.1,.23])<br>
+**`raw`**<br>
+Overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw `[.4,.1,.23]`)
 
-## airfoil_simple_wing help: 
+**`res_bias`** _(min: `1`, max: `c`, default: `2`)_<br>
+Resolution bias towards forward edge for cleaner curve. Lower = more bias.
+
+> [!NOTE]
+> This will remove resolution from trailing edge, but is only really noticible with camber positions greater than 70% (naca > x7xx). The default is probably fine for 95% of uses.
+
+## `airfoil_simple_wing` parameters:
+
 This will generate a simple wing based on one or more supplied airfoils. Each set of airfoils is an individual shape, allowing for very complex variation along the wing.
 
-***airfoils*** (required): 
+**`airfoils`**<br>
 Two modes:
 
-*Single Airfoil*: Specifying a single airfoil will generate a uniform wing based on that airfoil. You can specify the airfoil as a set (vector) of [chord, naca].
+1. _Single airfoil_: Specifying a single airfoil will generate a uniform wing based on that airfoil. You can specify the airfoil as a set (vector) of `[chord, naca]`.
 
-*Multiple airfoils*: Specify a set (vector) of airfoils. Individual airfoils are specified the same as a single airfoil (see above). These airfoils will be spaced evenly along the wing length.
+2. _Multiple airfoils_: Specify a set (vector) of airfoils. Individual airfoils are specified the same as a single airfoil (see above). These airfoils will be spaced evenly along the wing length.
 
-***wing_angle***: a set of angles, \[sweep,slope\]. Sweep is along the x axis, slope along the y axis. (optional, default=[0,0])
+**`wing_angle`** _(optional, default=`[0,0]`)_<br>
+A set of angles, \[sweep,slope\]. Sweep is along the x axis, slope along the y axis.
 
-***wing_length***: length of the wing (optional, default=1000)
+**`wing_length`** _(optional, default=`1000`)_<br>
+Length of the wing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenSCAD_airfoil
 
-## Parametric Airfoil and Wing Generator v0.1
+## Parametric Airfoil and Wing Generator v0.2
 
 Homepage: https://github.com/ErroneousBosch/OpenSCAD_airfoil
 

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -64,8 +64,10 @@ module airfoil_poly(c = 100, naca = 0015, raw = false) {
 }
 
 // Todo: Wings, w/angles
+
 // Airfoil definition = [c,naca]
 module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 1000) {
+
   if (airfoils != false) {
     if (!is_list(airfoils[0])) {
       validate(airfoils, print=false);
@@ -105,7 +107,10 @@ module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 
       }
     }
   } else {
-    echo("No Airfoils defined! Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more for compound wing. If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length.");
+    echo(
+      "No Airfoils defined! Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more for compound wing.\
+      If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length."
+    );
   }
 }
 
@@ -126,6 +131,6 @@ module airfoil_help() {
     <b><i>wing_length</b></i>: length of the wing (optional, default=1000)"
   );
 }
-airfoil_help();
-//translate([0,0,100]) airfoil_poly();
-//airfoil_simple_wing(airfoils=[[100,0015],[200,2414],[100,0015],[200,2414],[100,0015]], wing_angle=[20,-20]);
+// airfoil_help();
+// translate([0,0,100]) airfoil_poly();
+// airfoil_simple_wing(airfoils=[[100,0015],[200,2414],[100,0015],[200,2414],[100,0015]], wing_angle=[20,-20]);

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -135,7 +135,7 @@ module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 
     }
   } else {
     echo(
-      "No Airfoils defined! Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more for compound wing.\
+      "No Airfoils defined! Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more for compound wing.
       If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length."
     );
   }
@@ -143,19 +143,24 @@ module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 
 
 module airfoil_help() {
   echo(
-    "<u><b>Parametric Airfoil and Wing generator v0.1</u></b> <br>\
-    For a brief overview of the math and specifications used, see https://en.wikipedia.org/wiki/NACA_airfoil<br>\
-    <u>Globals:</u><br> \
-    <b><i>$close_airfoils</b></i>: Defines whether you want the back of your air foils closed, or if you want them open (default: false) <br>\
-    <b><i>$airfoil_fn</b></i>: number of sides for your airfoil. (default: 100) <br>\
-    <u>airfoil_poly help:</u><br>\
-    <b><i>c</b></i>: Chord length, this is the chord length of your airfoil. (default: 100) <br>\
-    <b><i>naca</b></i>: The NACA 4-digit specification for your airfoil. (default: 0015) <br>\
-    <b><i>raw</b></i>: overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw [.4,.1,.23])<br>
-    <u>airfoil_simple_wing help:</u> <br>\
-    <b><i>airfoils</b></i>: Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more in a vector for compound wing. If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length. (required)<br>\
-    <b><i>wing_angle</b></i>: a set of angles, [sweep,slope] (optional, default=[0,0])<br>\
-    <b><i>wing_length</b></i>: length of the wing (optional, default=1000)"
+    "\n
+    # Parametric Airfoil and Wing Generator v0.2\n
+    For a brief overview of the math and specifications used, see https://en.wikipedia.org/wiki/NACA_airfoil\n
+   \n
+    ## Globals:\n
+    - `$close_airfoils`: Defines whether you want the back of your air foils closed, or if you want them open (default: false)\n
+    - `$airfoil_fn`: number of sides for your airfoil. (default: 100)\n
+   \n
+    ### `airfoil_poly` args:\n
+    - `c`: Chord length, this is the chord length of your airfoil. (default: 100)\n
+    - `naca`: The NACA 4-digit specification for your airfoil. (default: 0015)\n
+    - `raw`: overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw `[.4,.1,.23]`)\n
+   \n
+    ### `airfoil_simple_wing` args:\n
+    - `airfoils`: Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more in a vector for compound wing. (required)\n
+      - If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length.\n
+    - `wing_angle`: a set of angles in the form `[sweep, slope]` (optional, default=[0,0])\n
+    - `wing_length`: length of the wing (optional, default=1000)"
   );
 }
 // airfoil_help();

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -1,5 +1,4 @@
-$airfoil_fn = 120;
-$close_airfoils = true;
+$debug = false;
 
 // https://en.wikipedia.org/wiki/NACA_airfoil
 
@@ -31,19 +30,25 @@ function camber_x(x, c, t, m, p, upper = true) =
     : (x + (foil_y(x, c, t) * sin(theta(x, c, m, p))))
   );
 
+module validate(spec, print = $debug) {
+  if (print == true) { echo(str("Validating spec ", spec)); }
+  assert(is_list(spec) && len(spec) == 2, "Airfoils must be specified as [chord, naca]");
+  assert(is_num(spec[0]) && 0 < spec[0], str("Invalid chord \"", spec[0], "\""));
+  assert(is_num(spec[1]) && 0 < spec[1] && spec[1] <= 9999, str("Invalid NACA specification \"", spec[1], "\""));
+}
+
 module airfoil_poly(c = 100, naca = 0015, raw = false) {
-  $close_airfoils = ($close_airfoils != undef) ? $close_airfoils : false;
-  $airfoil_fn = ($airfoil_fn != undef) ? $airfoil_fn : 100;
-  res = c / $airfoil_fn; // resolution of foil poly
 
-  // establish thickness/length ratio
-  t = (raw == false) ? ( (naca % 100) / 100) : raw[2];
-  // maximum camber:chord
-  m = (raw == false) ? ( (floor(( ( (naca - (naca % 100)) / 1000) )) / 100) ) : raw[0];
-  //distance of maximum camber from the airfoil leading edge in tenths of the chord
-  p = (raw == false) ? ( ( ( (naca - (naca % 100)) / 100) % 10) / 10) : raw[1];
+  validate([c, raw == true ? 0 : naca]);
 
-  // points have to be generated with or without camber, depending.
+  // Maximum camber:chord
+  // Points have to be generated with or without camber, depending.
+  // Distance of maximum camber from the airfoil leading edge in tenths of the chord
+  p = (raw == true) ? raw[1] : ( ( ( (naca - (naca % 100)) / 100) % 10) / 10);
+  // Establish thickness/length ratio
+  t = (raw == true) ? raw[2] : ( (naca % 100) / 100);
+
+  // Points have to be generated with or without camber, depending.
   points_u =
     (m == 0 || p == 0) ?
       [for (i = [0:res:c]) let (x = i, y = foil_y(i, c, t)) [x, y]]
@@ -53,7 +58,8 @@ module airfoil_poly(c = 100, naca = 0015, raw = false) {
     (m == 0 || p == 0) ?
       [for (i = [c:-1 * res:0]) let (x = i, y = foil_y(i, c, t) * -1) [x, y]]
     : [for (i = [c:-1 * res:0]) let (x = camber_x(i, c, t, m, p, upper=false), y = camber_y(i, c, t, m, p, upper=false)) [x, y]];
-
+    if (!is_list(airfoils[0])) {
+      validate(airfoils, print=false);
   polygon(concat(points_u, points_l)); // draw poly
 }
 
@@ -61,7 +67,8 @@ module airfoil_poly(c = 100, naca = 0015, raw = false) {
 // Airfoil definition = [c,naca]
 module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 1000) {
   if (airfoils != false) {
-    if (len(airfoils[0]) == undef) {
+    if (!is_list(airfoils[0])) {
+      validate(airfoils, print=false);
       hull() {
         linear_extrude(0.1)
           airfoil_poly(airfoils[0], airfoils[1]);

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -39,7 +39,7 @@ module validate(spec, print = $debug) {
   assert(is_num(spec[1]) && 0 < spec[1] && spec[1] <= 9999, str("Invalid NACA specification \"", spec[1], "\""));
 }
 
-module airfoil_poly(c = 100, naca = 0015, raw = false) {
+module airfoil_poly(c = 100, naca = 0015, raw = false, res_bias=2) {
 
   validate([c, raw == true ? 0 : naca]);
   $airfoil_fn = !is_undef($airfoil_fn) ? $airfoil_fn : 25;
@@ -52,16 +52,6 @@ module airfoil_poly(c = 100, naca = 0015, raw = false) {
   p = (raw == true) ? raw[1] : ( ( ( (naca - (naca % 100)) / 100) % 10) / 10);
   // Establish thickness/length ratio
   t = (raw == true) ? raw[2] : ( (naca % 100) / 100);
-
-  /*
-  Resolution bias towards forward edge for cleaner curve (lower = more bias).
-
-  Careful, this will remove resolution from trailing edge, but only
-  really noticible with camber positions greater than 70% (naca > x7xx).
-
-  No bias = chord (var c)
-  */
-  res_bias = 2;
 
   // Points have to be generated with or without camber, depending.
   res_map_u = [for (x = [0:res:c]) x * min(1, x / (c / res_bias))];
@@ -154,13 +144,17 @@ module airfoil_help() {
     ### `airfoil_poly` args:\n
     - `c`: Chord length, this is the chord length of your airfoil. (default: 100)\n
     - `naca`: The NACA 4-digit specification for your airfoil. (default: 0015)\n
-    - `raw`: overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw `[.4,.1,.23]`)\n
+    - `raw`: Overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw `[.4,.1,.23]`)\n
+    - `res_bias`: Resolution bias towards forward edge for cleaner curve (lower = more bias).
+      - Careful, this will remove resolution from trailing edge, but only really noticible with camber positions greater than 70% (naca > x7xx).
+
+  No bias = chord (var c)
    \n
     ### `airfoil_simple_wing` args:\n
     - `airfoils`: Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more in a vector for compound wing. (required)\n
       - If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length.\n
-    - `wing_angle`: a set of angles in the form `[sweep, slope]` (optional, default=[0,0])\n
-    - `wing_length`: length of the wing (optional, default=1000)"
+    - `wing_angle`: A set of angles in the form `[sweep, slope]` (optional, default=[0,0])\n
+    - `wing_length`: Length of the wing (optional, default=1000)"
   );
 }
 // airfoil_help();

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -1,5 +1,7 @@
-// $airfoil_fn = !is_undef($airfoil_fn) && is_num($airfoil_fn) ? $airfoil_fn : 25;
-// $close_airfoils = !is_undef($close_airfoils) && is_bool($close_airfoils) ? $close_airfoils : true;
+// When including this in your project, consider commenting these
+// and defining them instead in your base project file
+$airfoil_fn = 25;
+$close_airfoils = true;
 $debug = false;
 
 // https://en.wikipedia.org/wiki/NACA_airfoil

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -1,92 +1,110 @@
 $airfoil_fn = 120;
 $close_airfoils = true;
 
-//https://en.wikipedia.org/wiki/NACA_airfoil
+// https://en.wikipedia.org/wiki/NACA_airfoil
 
-  function foil_y(x, c, t) = 
-(5*t*c)*( ( 0.2969 * sqrt(x/c) ) - ( 0.1260*(x/c) ) - ( 0.3516*pow((x/c),2) ) + ( 0.2843*pow((x/c),3) ) - ( ( $close_airfoils ? 0.1036 : 0.1015)*pow((x/c),4) ) ); //NACA symetrical airfoil formula
-  function camber(x,c,m,p) = ( x <= (p * c) ? 
-    ( ( (c * m)/pow( p, 2 ) ) * ( ( 2 * p * (x / c) ) - pow( (x / c) , 2) ) ) :
-    ( ( (c * m)/pow((1 - p),2) ) * ( (1-(2 * p) ) + ( 2 * p * (x / c) ) - pow( (x / c) ,  2)))
-    );
-  function theta(x,c,m,p) = ( x <= (p * c) ? 
-    atan( ((m)/pow(p,2)) * (p - (x / c)) ) :
-    atan( ((m)/pow((1 - p),2)) * (p - (x / c))  ) 
-    );
-  function camber_y(x,c,t,m,p, upper=true) = ( upper == true ?
-  ( camber(x,c,m,p) + (foil_y(x,c,t) * cos( theta(x,c,m,p) ) ) ) :
-  ( camber(x,c,m,p) - (foil_y(x,c,t) * cos( theta(x,c,m,p) ) ) )
+function foil_y(x, c, t) =
+  // NACA symmetrical airfoil formula
+  (5 * t * c) * ( (0.2969 * sqrt(x / c)) - (0.1260 * (x / c)) - (0.3516 * pow((x / c), 2)) + (0.2843 * pow((x / c), 3)) - ( ($close_airfoils ? 0.1036 : 0.1015) * pow((x / c), 4)));
+function camber(x, c, m, p) =
+  (
+    x <= (p * c) ?
+      ( ( (c * m) / pow(p, 2)) * ( (2 * p * (x / c)) - pow((x / c), 2)))
+    : ( ( (c * m) / pow((1 - p), 2)) * ( (1 - (2 * p)) + (2 * p * (x / c)) - pow((x / c), 2)))
   );
-  function camber_x(x,c,t,m,p, upper=true) = ( upper == true ?
-  ( x - (foil_y(x,c,t) * sin( theta(x,c,m,p) ) ) ) :
-  ( x + (foil_y(x,c,t) * sin( theta(x,c,m,p) ) ) )
+function theta(x, c, m, p) =
+  (
+    x <= (p * c) ?
+      atan(( (m) / pow(p, 2)) * (p - (x / c)))
+    : atan(( (m) / pow((1 - p), 2)) * (p - (x / c)))
   );
-  
-  
-module airfoil_poly (c = 100, naca = 0015, raw=false) {
+function camber_y(x, c, t, m, p, upper = true) =
+  (
+    upper == true ?
+      (camber(x, c, m, p) + (foil_y(x, c, t) * cos(theta(x, c, m, p))))
+    : (camber(x, c, m, p) - (foil_y(x, c, t) * cos(theta(x, c, m, p))))
+  );
+function camber_x(x, c, t, m, p, upper = true) =
+  (
+    upper == true ?
+      (x - (foil_y(x, c, t) * sin(theta(x, c, m, p))))
+    : (x + (foil_y(x, c, t) * sin(theta(x, c, m, p))))
+  );
+
+module airfoil_poly(c = 100, naca = 0015, raw = false) {
   $close_airfoils = ($close_airfoils != undef) ? $close_airfoils : false;
   $airfoil_fn = ($airfoil_fn != undef) ? $airfoil_fn : 100;
-  res = c/$airfoil_fn; //resolution of foil poly 
-    
-    //establish thickness/length ratio
-    t = (raw == false) ? ((naca%100)/100) : raw[2]; 
-    // maximum camber:chord
-    m = (raw == false) ?((floor((((naca-(naca%100))/1000))) /100) ):raw[0];
-    //distance of maximum camber from the airfoil leading edge in tenths of the chord
-    p = (raw == false) ?((((naca-(naca%100))/100)%10) / 10): raw[1];
+  res = c / $airfoil_fn; // resolution of foil poly
 
-    
-  // points have to be generated with or without camber, depending. 
-    points_u = ( m == 0 || p == 0) ?
-     [for (i = [0:res:c]) let (x = i, y = foil_y(i,c,t) ) [x,y]] :
-     [for (i = [0:res:c]) let (x = camber_x(i,c,t,m,p), y = camber_y(i,c,t,m,p) ) [x,y]] ;
-    
-    points_l = ( m == 0 || p == 0) ?
-     [for (i = [c:-1*res:0]) let (x = i, y = foil_y(i,c,t) * -1 ) [x,y]] :
-     [for (i = [c:-1*res:0]) let (x = camber_x(i,c,t,m,p,upper=false), y = camber_y(i,c,t,m,p, upper=false) ) [x,y]] ;    
- 
-   polygon(concat(points_u,points_l)); //draw poly
+  // establish thickness/length ratio
+  t = (raw == false) ? ( (naca % 100) / 100) : raw[2];
+  // maximum camber:chord
+  m = (raw == false) ? ( (floor(( ( (naca - (naca % 100)) / 1000) )) / 100) ) : raw[0];
+  //distance of maximum camber from the airfoil leading edge in tenths of the chord
+  p = (raw == false) ? ( ( ( (naca - (naca % 100)) / 100) % 10) / 10) : raw[1];
+
+  // points have to be generated with or without camber, depending.
+  points_u =
+    (m == 0 || p == 0) ?
+      [for (i = [0:res:c]) let (x = i, y = foil_y(i, c, t)) [x, y]]
+    : [for (i = [0:res:c]) let (x = camber_x(i, c, t, m, p), y = camber_y(i, c, t, m, p)) [x, y]];
+
+  points_l =
+    (m == 0 || p == 0) ?
+      [for (i = [c:-1 * res:0]) let (x = i, y = foil_y(i, c, t) * -1) [x, y]]
+    : [for (i = [c:-1 * res:0]) let (x = camber_x(i, c, t, m, p, upper=false), y = camber_y(i, c, t, m, p, upper=false)) [x, y]];
+
+  polygon(concat(points_u, points_l)); // draw poly
 }
 
-//Todo: Wings, w/angles
+// Todo: Wings, w/angles
 // Airfoil definition = [c,naca]
-module airfoil_simple_wing (airfoils=false, wing_angle=[0,0], wing_length=1000){
-    
-    if (airfoils != false) {
-        if (len(airfoils[0]) == undef) {
-            hull(){
-                
-                linear_extrude(0.1) airfoil_poly(airfoils[0],airfoils[1]);
-                
-                translate([(sin(wing_angle[0]) * wing_length),(sin(wing_angle[1]) * wing_length),wing_length])          linear_extrude(0.1) airfoil_poly(airfoils[0],airfoils[1]);
-            
-            }
-        }
-        else {
-            union(){
-                for( i=[1:len(airfoils)-1] ) {
-                    hull() {
-                        
-                        translate([(sin(wing_angle[0]) * wing_length * (i-1)/len(airfoils)),
-                        (sin(wing_angle[1]) * wing_length * (i-1)/len(airfoils)),
-                        wing_length * (i-1)/len(airfoils)])
-                        linear_extrude(0.1) airfoil_poly(airfoils[(i-1)][0],airfoils[(i-1)][1]);
-                        
-                        translate([(sin(wing_angle[0]) * wing_length * i/len(airfoils)),
-                        (sin(wing_angle[1]) * wing_length * i/len(airfoils)),
-                        wing_length * i/len(airfoils)])
-                        linear_extrude(0.1) airfoil_poly(airfoils[i][0],airfoils[i][1]);
+module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 1000) {
+  if (airfoils != false) {
+    if (len(airfoils[0]) == undef) {
+      hull() {
+        linear_extrude(0.1)
+          airfoil_poly(airfoils[0], airfoils[1]);
 
-                    }
-                }
-            }
-        }
+        translate([(sin(wing_angle[0]) * wing_length), (sin(wing_angle[1]) * wing_length), wing_length])
+          linear_extrude(0.1)
+            airfoil_poly(airfoils[0], airfoils[1]);
+      }
     } else {
-        echo("No Airfoils defined! Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more for compound wing. If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length.");
+      union() {
+        for (i = [1:len(airfoils) - 1]) {
+          hull() {
+            translate(
+              [
+                (sin(wing_angle[0]) * wing_length * (i - 1) / len(airfoils)),
+                (sin(wing_angle[1]) * wing_length * (i - 1) / len(airfoils)),
+                wing_length * (i - 1) / len(airfoils),
+              ]
+            )
+              linear_extrude(0.1)
+                airfoil_poly(airfoils[ (i - 1) ][0], airfoils[ (i - 1) ][1]);
+
+            translate(
+              [
+                (sin(wing_angle[0]) * wing_length * i / len(airfoils)),
+                (sin(wing_angle[1]) * wing_length * i / len(airfoils)),
+                wing_length * i / len(airfoils),
+              ]
+            )
+              linear_extrude(0.1)
+                airfoil_poly(airfoils[i][0], airfoils[i][1]);
+          }
+        }
+      }
     }
+  } else {
+    echo("No Airfoils defined! Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more for compound wing. If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length.");
+  }
 }
-module airfoil_help(){
-    echo("<u><b>Parametric Airfoil and Wing generator v0.1</u></b> <br>\
+
+module airfoil_help() {
+  echo(
+    "<u><b>Parametric Airfoil and Wing generator v0.1</u></b> <br>\
     For a brief overview of the math and specifications used, see https://en.wikipedia.org/wiki/NACA_airfoil<br>\
     <u>Globals:</u><br> \
     <b><i>$close_airfoils</b></i>: Defines whether you want the back of your air foils closed, or if you want them open (default: false) <br>\
@@ -98,7 +116,8 @@ module airfoil_help(){
     <u>airfoil_simple_wing help:</u> <br>\
     <b><i>airfoils</b></i>: Airfoils should be a set of [chord, naca]. Specify one for a uniform wing, two or more in a vector for compound wing. If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length. (required)<br>\
     <b><i>wing_angle</b></i>: a set of angles, [sweep,slope] (optional, default=[0,0])<br>\
-    <b><i>wing_length</b></i>: length of the wing (optional, default=1000)");
+    <b><i>wing_length</b></i>: length of the wing (optional, default=1000)"
+  );
 }
 airfoil_help();
 //translate([0,0,100]) airfoil_poly();

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -1,3 +1,5 @@
+// $airfoil_fn = !is_undef($airfoil_fn) && is_num($airfoil_fn) ? $airfoil_fn : 25;
+// $close_airfoils = !is_undef($close_airfoils) && is_bool($close_airfoils) ? $close_airfoils : true;
 $debug = false;
 
 // https://en.wikipedia.org/wiki/NACA_airfoil
@@ -40,27 +42,47 @@ module validate(spec, print = $debug) {
 module airfoil_poly(c = 100, naca = 0015, raw = false) {
 
   validate([c, raw == true ? 0 : naca]);
+  $airfoil_fn = !is_undef($airfoil_fn) ? $airfoil_fn : 25;
+  $close_airfoils = !is_undef($close_airfoils) ? $close_airfoils : true;
+  res = c / $airfoil_fn; // Resolution of foil poly
 
   // Maximum camber:chord
-  // Points have to be generated with or without camber, depending.
+  m = (raw == true) ? raw[0] : ( (floor(( ( (naca - (naca % 100)) / 1000) )) / 100) );
   // Distance of maximum camber from the airfoil leading edge in tenths of the chord
   p = (raw == true) ? raw[1] : ( ( ( (naca - (naca % 100)) / 100) % 10) / 10);
   // Establish thickness/length ratio
   t = (raw == true) ? raw[2] : ( (naca % 100) / 100);
 
+  /*
+  Resolution bias towards forward edge for cleaner curve (lower = more bias).
+
+  Careful, this will remove resolution from trailing edge, but only
+  really noticible with camber positions greater than 70% (naca > x7xx).
+
+  No bias = chord (var c)
+  */
+  res_bias = 2;
+
   // Points have to be generated with or without camber, depending.
+  res_map_u = [for (x = [0:res:c]) x * min(1, x / (c / res_bias))];
+  if ($debug == true) { echo(res_map_u=res_map_u); }
   points_u =
     (m == 0 || p == 0) ?
-      [for (i = [0:res:c]) let (x = i, y = foil_y(i, c, t)) [x, y]]
-    : [for (i = [0:res:c]) let (x = camber_x(i, c, t, m, p), y = camber_y(i, c, t, m, p)) [x, y]];
+      [for (i = res_map_u) let (x = i, y = foil_y(i, c, t)) [x, y]]
+    : [for (i = res_map_u) let (x = camber_x(i, c, t, m, p), y = camber_y(i, c, t, m, p)) [x, y]];
 
+  res_map_l = [for (x = [c:-res:0]) x * min(1, x / (c / res_bias))];
+  if ($debug == true) { echo(res_map_l=res_map_l); }
   points_l =
     (m == 0 || p == 0) ?
-      [for (i = [c:-1 * res:0]) let (x = i, y = foil_y(i, c, t) * -1) [x, y]]
-    : [for (i = [c:-1 * res:0]) let (x = camber_x(i, c, t, m, p, upper=false), y = camber_y(i, c, t, m, p, upper=false)) [x, y]];
-    if (!is_list(airfoils[0])) {
-      validate(airfoils, print=false);
-  polygon(concat(points_u, points_l)); // draw poly
+      [for (i = res_map_l) let (x = i, y = foil_y(i, c, t) * -1) [x, y]]
+    : [for (i = res_map_l) let (x = camber_x(i, c, t, m, p, upper=false), y = camber_y(i, c, t, m, p, upper=false)) [x, y]];
+
+  if ($debug == true) {
+    echo(points_u=points_u);
+    echo(points_l=points_l);
+  }
+  polygon(concat(points_u, points_l)); // Draw poly
 }
 
 // Todo: Wings, w/angles

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -80,14 +80,19 @@ module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 
             airfoil_poly(airfoils[0], airfoils[1]);
       }
     } else {
+      if ($debug == true) { echo(wing_length=wing_length); }
       union() {
-        for (i = [1:len(airfoils) - 1]) {
+        segments = len(airfoils) - 1;
+        segment_length = wing_length / segments;
+        for (i = [1:segments]) {
+          validate(airfoils[i - 1], print=false);
+          if ($debug == true) { echo(str("segment from ", segment_length * (i - 1), " to ", segment_length * i)); }
           hull() {
             translate(
               [
-                (sin(wing_angle[0]) * wing_length * (i - 1) / len(airfoils)),
-                (sin(wing_angle[1]) * wing_length * (i - 1) / len(airfoils)),
-                wing_length * (i - 1) / len(airfoils),
+                (sin(wing_angle[0]) * wing_length * (i - 1) / segments),
+                (sin(wing_angle[1]) * wing_length * (i - 1) / segments),
+                segment_length * (i - 1),
               ]
             )
               linear_extrude(0.1)
@@ -95,9 +100,9 @@ module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 
 
             translate(
               [
-                (sin(wing_angle[0]) * wing_length * i / len(airfoils)),
-                (sin(wing_angle[1]) * wing_length * i / len(airfoils)),
-                wing_length * i / len(airfoils),
+                (sin(wing_angle[0]) * wing_length * i / segments),
+                (sin(wing_angle[1]) * wing_length * i / segments),
+                segment_length * i,
               ]
             )
               linear_extrude(0.1)

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -34,16 +34,17 @@ function camber_x(x, c, t, m, p, upper = true) =
     : (x + (foil_y(x, c, t) * sin(theta(x, c, m, p))))
   );
 
-module validate(spec, print = $debug) {
+module validate(spec, res_bias = 2, print = $debug) {
   if (print == true) { echo(str("Validating spec ", spec)); }
   assert(is_list(spec) && len(spec) == 2, "Airfoils must be specified as [chord, naca]");
   assert(is_num(spec[0]) && 0 < spec[0], str("Invalid chord \"", spec[0], "\""));
   assert(is_num(spec[1]) && 0 < spec[1] && spec[1] <= 9999, str("Invalid NACA specification \"", spec[1], "\""));
+  assert(is_num(res_bias) && 1 <= res_bias && res_bias <= spec[0], str("Invalid resolution bias \"", res_bias, "\" (min: 1, max: ", spec[0], ")"));
 }
 
-module airfoil_poly(c = 100, naca = 0015, raw = false, res_bias=2) {
+module airfoil_poly(c = 100, naca = 0015, raw = false, res_bias = 2) {
 
-  validate([c, raw == true ? 0 : naca]);
+  validate([c, raw == true ? 0 : naca], res_bias);
   $airfoil_fn = !is_undef($airfoil_fn) ? $airfoil_fn : 25;
   $close_airfoils = !is_undef($close_airfoils) ? $close_airfoils : true;
   res = c / $airfoil_fn; // Resolution of foil poly

--- a/airfoil.scad
+++ b/airfoil.scad
@@ -128,7 +128,7 @@ module airfoil_simple_wing(airfoils = false, wing_angle = [0, 0], wing_length = 
     }
   } else {
     echo(
-      "No Airfoils defined! Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more for compound wing.
+      "No Airfoils defined! Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more for compound wing.\n
       If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length."
     );
   }
@@ -141,25 +141,23 @@ module airfoil_help() {
     For a brief overview of the math and specifications used, see https://en.wikipedia.org/wiki/NACA_airfoil\n
    \n
     ## Globals:\n
-    - `$close_airfoils`: Defines whether you want the back of your air foils closed, or if you want them open (default: false)\n
-    - `$airfoil_fn`: number of sides for your airfoil. (default: 100)\n
+    - `$close_airfoils`: Defines whether you want the back of your air foils closed, or if you want them open (default: `false`)\n
+    - `$airfoil_fn`: number of sides for your airfoil. (default: `100`)\n
    \n
     ### `airfoil_poly` args:\n
-    - `c`: Chord length, this is the chord length of your airfoil. (default: 100)\n
-    - `naca`: The NACA 4-digit specification for your airfoil. (default: 0015)\n
+    - `c`: Chord length, this is the chord length of your airfoil. (default: `100`)\n
+    - `naca`: The NACA 4-digit specification for your airfoil. (default: `0015`)\n
     - `raw`: Overrides the NACA code with direct ratios. Provide in the same order as the NACA digits. (e.g NACA 4123 becomes raw `[.4,.1,.23]`)\n
-    - `res_bias`: Resolution bias towards forward edge for cleaner curve (lower = more bias).
-      - Careful, this will remove resolution from trailing edge, but only really noticible with camber positions greater than 70% (naca > x7xx).
-
-  No bias = chord (var c)
+    - `res_bias`: Resolution bias towards forward edge for cleaner curve. Lower = more bias. (min: `1`, max (no bias): `c`, default: `2`)\n
+      - Careful, this will remove resolution from trailing edge, but only really noticible with camber positions greater than 70% (naca > x7xx).\n
    \n
     ### `airfoil_simple_wing` args:\n
-    - `airfoils`: Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more in a vector for compound wing. (required)\n
+    - `airfoils`: Airfoils should be a set of `[chord, naca]`. Specify one for a uniform wing, two or more in a vector for compound wing.\n
       - If specifying only one, do not put it in a set/vector. Multiple airfoils will be spaced evenly along the wing length.\n
-    - `wing_angle`: A set of angles in the form `[sweep, slope]` (optional, default=[0,0])\n
-    - `wing_length`: Length of the wing (optional, default=1000)"
+    - `wing_angle`: A set of angles in the form `[sweep, slope]`. (optional, default=`[0,0]`)\n
+    - `wing_length`: Length of the wing. (optional, default=`1000`)"
   );
 }
-// airfoil_help();
+airfoil_help();
 // translate([0,0,100]) airfoil_poly();
 // airfoil_simple_wing(airfoils=[[100,0015],[200,2414],[100,0015],[200,2414],[100,0015]], wing_angle=[20,-20]);


### PR DESCRIPTION
The main feature of this PR is the addition of the `res_bias` parameter to the `airfoil_poly` function. This controls how much the resolution of polygon points is biased towards the leading edge of the wing where the curvature is highest. With the default value of 2, a wing with `$airfoil_fn = 25` has the same quality as a wing with `$airfoil_fn = 100` using the former equidistant method. In my current project with ~40 linear extruded `airfoil_poly`, this has improved performance a good bit.

In addition, a validation function has been added to produce more descriptive error messages when invalid parameter values are provided. This also fixes a couple bugs I found where invalid parameter values would completely hang the program.

Finally, I updated and prettied up the README.